### PR TITLE
queried the recommendation model and serialized the recommendations i…

### DIFF
--- a/bangazonapi/models/recommendation.py
+++ b/bangazonapi/models/recommendation.py
@@ -5,6 +5,17 @@ from .product import Product
 
 class Recommendation(models.Model):
 
-    customer = models.ForeignKey(Customer, related_name='customer', on_delete=models.DO_NOTHING,)
-    product = models.ForeignKey(Product, on_delete=models.DO_NOTHING,)
-    recommender = models.ForeignKey(Customer, related_name='recommender', on_delete=models.DO_NOTHING,)
+    customer = models.ForeignKey(
+        Customer,
+        related_name="customer",
+        on_delete=models.DO_NOTHING,
+    )
+    product = models.ForeignKey(
+        Product,
+        on_delete=models.DO_NOTHING,
+    )
+    recommender = models.ForeignKey(
+        Customer,
+        related_name="recommender",
+        on_delete=models.DO_NOTHING,
+    )

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -401,6 +401,7 @@ class RecommenderSerializer(serializers.ModelSerializer):
 class ProfileSerializer(serializers.ModelSerializer):
     user = UserSerializer(many=False)
     recommends = serializers.SerializerMethodField()
+    recommended_to_me = serializers.SerializerMethodField()
     payment_types = serializers.HyperlinkedRelatedField(
         many=True,
         read_only=True,
@@ -417,11 +418,16 @@ class ProfileSerializer(serializers.ModelSerializer):
             "address",
             "payment_types",
             "recommends",
+            "recommended_to_me",
         )
         depth = 1
 
     def get_recommends(self, customer):
         recs = Recommendation.objects.filter(recommender=customer)
+        return RecommenderSerializer(recs, many=True, context=self.context).data
+
+    def get_recommended_to_me(self, customer):
+        recs = Recommendation.objects.filter(customer=customer)
         return RecommenderSerializer(recs, many=True, context=self.context).data
 
 


### PR DESCRIPTION
This PR adds the ability for users to see products that have been recommended to them on their profile page.

### What changed:

Added a [recommended_to_me] field to the profile serializer.
Now, when you view your profile, you’ll see both:
- Products you’ve recommended to others ([recommends]
- Products that other users have recommended to you ([recommended_to_me]
 
### How it works:

The backend grabs all [Recommendation] objects where you are the recipient and sends them in the profile response.
Frontend can now display a "Recommended Items" section for stuff people have suggested to you.

Let me know if you spot any issues or want to tweak the display!